### PR TITLE
Make the code viewable on phones by flex-wrap

### DIFF
--- a/examples/coffeeshop.html
+++ b/examples/coffeeshop.html
@@ -35,7 +35,7 @@
     .header .introButton:hover { box-shadow: 0 4px 4px rgba(0,0,0,.3); top: 0px; border:2px solid #F08000; }
     .introButton:active { top:0px; background:#20262E; color:#FFF }
     .introButton.active { animation: ani .5s infinite; }
-    .content       { width:100%; height:100%; flex-grow:1; overflow:hidden; display:flex; box-sizing:border-box; max-width:100vw; position:relative;  }
+    .content       { width:100%; height:100%; flex-grow:1; flex-wrap:wrap; overflow:hidden; display:flex; box-sizing:border-box; max-width:100vw; position:relative;  }
     .gutter        { background: #2d333b; min-width:4px; min-height:100%; cursor:ew-resize;}
     .left          { width: 433px; box-sizing:border-box; flex-grow:0; flex-shrink:0; overflow:hidden; flex-flow:wrap; max-height:100%; position:relative; user-select:none; }
     .leftc         { width: 100%; box-sizing:border-box; flex-grow:0; flex-shrink:0; overflow:hidden; overflow-Y:auto; flex-flow:wrap; max-height:calc(100% - 35px); }
@@ -83,7 +83,7 @@
     .help td { text-align:center; padding-top:3px; }
     @media only screen and (max-device-width: 600px) {
       .left { width : 150px; }
-      .right { width : 1px; }
+      .right { width : 100vw; }
     }
     @media only screen and (max-device-width: 1200px) {
       .left { width : 150px; }


### PR DESCRIPTION
The result looks like this:

![image](https://user-images.githubusercontent.com/64258/59087670-ee8dfc80-8937-11e9-99ab-3fa054d09d52.png)

![image](https://user-images.githubusercontent.com/64258/59087681-f5b50a80-8937-11e9-8395-fcc9a6c50a7f.png)

And if one wishes to see the fullscreen view (without code), one can add `&fullscreen` to the end of the url.
